### PR TITLE
Rebuild against python 3.14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
-
+!/abs.yaml
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.
 !/**/

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_parameters:
+  - "--no-test"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,36 +22,36 @@ requirements:
     - jupyterlab >=4.0.0
     - hatch-nodejs-version
     - hatch-jupyter-builder >=0.5
-#   run:
-#     - python
-#     - ploomber-core
-#     - jupysql
+  run:
+    - python
+    - ploomber-core
+    - jupysql
 
-# # sqlalchemy.exc.NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:duckdb
-# {% set deselect_tests = " --deselect=tests/test_connections.py::test_save_connection_to_config_file_and_connect_in_nested_dir[default]" %}
-# {% set deselect_tests = deselect_tests + " --deselect=tests/test_connections.py::test_save_connection_to_config_file_and_connect_in_nested_dir[nested]" %}
-# {% set deselect_tests = deselect_tests + " --deselect=tests/test_connector_widget.py::test_method_submit_new_connection" %}
-# {% set deselect_tests = deselect_tests + " --deselect=tests/test_connector_widget.py::test_method_submit_new_connection_path" %}
-# {% set deselect_tests = deselect_tests + " --deselect=tests/test_connector_widget.py::test_method_connect" %}
-# # E           AttributeError: 'ConfigParser' object has no attribute 'readfp'. Did you mean: 'read'?
-# {% set deselect_tests = deselect_tests + " --deselect=tests/test_connections.py::test_delete_section_with_name" %}
+# sqlalchemy.exc.NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:duckdb
+{% set deselect_tests = " --deselect=tests/test_connections.py::test_save_connection_to_config_file_and_connect_in_nested_dir[default]" %}
+{% set deselect_tests = deselect_tests + " --deselect=tests/test_connections.py::test_save_connection_to_config_file_and_connect_in_nested_dir[nested]" %}
+{% set deselect_tests = deselect_tests + " --deselect=tests/test_connector_widget.py::test_method_submit_new_connection" %}
+{% set deselect_tests = deselect_tests + " --deselect=tests/test_connector_widget.py::test_method_submit_new_connection_path" %}
+{% set deselect_tests = deselect_tests + " --deselect=tests/test_connector_widget.py::test_method_connect" %}
+# E           AttributeError: 'ConfigParser' object has no attribute 'readfp'. Did you mean: 'read'?
+{% set deselect_tests = deselect_tests + " --deselect=tests/test_connections.py::test_delete_section_with_name" %}
 
-# test:
-#   source_files:
-#     - tests
-#   imports:
-#     - jupysql_plugin
-#   commands:
-#     - pip check
-#     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-#     - pytest -v tests {{ deselect_tests }}
-#   requires:
-#     - pip
-#     - pytest
-#     - jupyter_server
-#     - pytest-jupyter
-#     - ipython
-#     - ipywidgets
+test:
+  source_files:
+    - tests
+  imports:
+    - jupysql_plugin
+  commands:
+    - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest -v tests {{ deselect_tests }}
+  requires:
+    - pip
+    - pytest
+    - jupyter_server
+    - pytest-jupyter
+    - ipython
+    - ipywidgets
 
 about:
   home: https://github.com/ploomber/jupysql-plugin

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 1
+  number: 2
   skip: True  # [py<37]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,36 +22,36 @@ requirements:
     - jupyterlab >=4.0.0
     - hatch-nodejs-version
     - hatch-jupyter-builder >=0.5
-  run:
-    - python
-    - ploomber-core
-    - jupysql
+#   run:
+#     - python
+#     - ploomber-core
+#     - jupysql
 
-# sqlalchemy.exc.NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:duckdb
-{% set deselect_tests = " --deselect=tests/test_connections.py::test_save_connection_to_config_file_and_connect_in_nested_dir[default]" %}
-{% set deselect_tests = deselect_tests + " --deselect=tests/test_connections.py::test_save_connection_to_config_file_and_connect_in_nested_dir[nested]" %}
-{% set deselect_tests = deselect_tests + " --deselect=tests/test_connector_widget.py::test_method_submit_new_connection" %}
-{% set deselect_tests = deselect_tests + " --deselect=tests/test_connector_widget.py::test_method_submit_new_connection_path" %}
-{% set deselect_tests = deselect_tests + " --deselect=tests/test_connector_widget.py::test_method_connect" %}
-# E           AttributeError: 'ConfigParser' object has no attribute 'readfp'. Did you mean: 'read'?
-{% set deselect_tests = deselect_tests + " --deselect=tests/test_connections.py::test_delete_section_with_name" %}
+# # sqlalchemy.exc.NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:duckdb
+# {% set deselect_tests = " --deselect=tests/test_connections.py::test_save_connection_to_config_file_and_connect_in_nested_dir[default]" %}
+# {% set deselect_tests = deselect_tests + " --deselect=tests/test_connections.py::test_save_connection_to_config_file_and_connect_in_nested_dir[nested]" %}
+# {% set deselect_tests = deselect_tests + " --deselect=tests/test_connector_widget.py::test_method_submit_new_connection" %}
+# {% set deselect_tests = deselect_tests + " --deselect=tests/test_connector_widget.py::test_method_submit_new_connection_path" %}
+# {% set deselect_tests = deselect_tests + " --deselect=tests/test_connector_widget.py::test_method_connect" %}
+# # E           AttributeError: 'ConfigParser' object has no attribute 'readfp'. Did you mean: 'read'?
+# {% set deselect_tests = deselect_tests + " --deselect=tests/test_connections.py::test_delete_section_with_name" %}
 
-test:
-  source_files:
-    - tests
-  imports:
-    - jupysql_plugin
-  commands:
-    - pip check
-    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    - pytest -v tests {{ deselect_tests }}
-  requires:
-    - pip
-    - pytest
-    - jupyter_server
-    - pytest-jupyter
-    - ipython
-    - ipywidgets
+# test:
+#   source_files:
+#     - tests
+#   imports:
+#     - jupysql_plugin
+#   commands:
+#     - pip check
+#     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+#     - pytest -v tests {{ deselect_tests }}
+#   requires:
+#     - pip
+#     - pytest
+#     - jupyter_server
+#     - pytest-jupyter
+#     - ipython
+#     - ipywidgets
 
 about:
   home: https://github.com/ploomber/jupysql-plugin


### PR DESCRIPTION
jupysql-plugin 0.4.5

**Destination channel:**  defaults

### Links

- [PKG-13476](https://anaconda.atlassian.net/browse/PKG-13476) 
- [Upstream repository](https://github.com/ploomber/jupysql-plugin/tree/0.4.5)

### Explanation of changes:
- Rebuild for python 3.14
- disable tests because of cycle dependency on jupysql


[PKG-13476]: https://anaconda.atlassian.net/browse/PKG-13476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ